### PR TITLE
Key Uri Format for HOTP and TOTP

### DIFF
--- a/src/oath/hotp.rs
+++ b/src/oath/hotp.rs
@@ -195,6 +195,74 @@ impl HOTP {
         };
         code == ref_code
     }
+
+    /// Returns the Key Uri Format according to the [Google authenticator
+    /// specification](https://github.com/google/google-authenticator/wiki/Key-Uri-Format).
+    /// This value can be used to generete QR codes which allow easy scanning by the end user.
+    /// Passing a issuer value and prefixing the label with that value is highly recommended.
+    ///
+    /// **WARNING**: The return value contains the secret key of the authentication process and
+    /// should only be displayed to the corresponding user.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// let key_ascii = "12345678901234567890".to_owned();
+    /// let mut hotp = libreauth::oath::HOTPBuilder::new()
+    ///     .ascii_key(&key_ascii)
+    ///     .finalize()
+    ///     .unwrap();
+    ///
+    /// let uri = hotp.key_uri_format("Provider1:alice@gmail.com", Some("Provider1"));
+    /// assert_eq!(
+    ///     uri,
+    ///     "otpauth://hotp/Provider1:alice@gmail.com?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&issuer=Provider1&counter=0&algorithm=SHA1&digits=6"
+    /// );
+    /// ```
+    pub fn key_uri_format(&self, label: &str, issuer: Option<&str>) -> String {
+        let secret = base32::encode(
+            base32::Alphabet::RFC4648 { padding: false },
+            self.key.as_slice(),
+        );
+
+        // STRONGLY RECOMMENDED: The issuer parameter is a string value indicating the 
+        // provider or service this account is associated with. If the issuer parameter
+        // is absent, issuer information may be taken from the issuer prefix of the label.
+        // If both issuer parameter and issuer label prefix are present, they should be equal.
+        let mut issuer_param = String::new();
+        if issuer.is_some() {
+            issuer_param = format!("&issuer={}", issuer.unwrap());
+        }
+
+        // OPTIONAL: The algorithm may have the values: SHA1 (Default), SHA256, SHA512
+        use super::HashFunction::*;
+        let algo = match self.hash_function {
+            Sha1 => "&algorithm=SHA1",
+            Sha256 => "&algorithm=SHA256",
+            Sha512 => "&algorithm=SHA512",
+            _ => "",
+        };
+
+        // OPTIONAL: The digits parameter may have the values 6 or 8, and determines how
+        // long of a one-time passcode to display to the user. The default is 6.
+        let out_len = self.output_len;
+        let mut digits = String::new();
+        if out_len == 6 || out_len == 8 {
+            digits = format!("&digits={}", out_len);
+        }
+
+        // REQUIRED if type is hotp: The counter parameter is required when provisioning 
+        // a key for use with HOTP. It will set the initial counter value.
+        let counter = format!("&counter={}", self.counter);
+
+        format!(
+            "otpauth://{key_type}/{label}?secret={secret}{params}",
+            key_type = "hotp",
+            label = label,
+            secret = secret,
+            params =  issuer_param + &counter + &algo + &digits,
+        )
+    }
 }
 
 /// Builds an HOTP object.
@@ -1333,5 +1401,35 @@ mod tests {
             .unwrap()
             .is_valid(&user_code);
         assert_eq!(valid, false);
+    }
+
+    #[test]
+    fn test_key_uri_format() {
+        let key_ascii = "12345678901234567890".to_owned();
+        let mut hotp = HOTPBuilder::new()
+            .ascii_key(&key_ascii)
+            .finalize()
+            .unwrap();
+
+        let uri = hotp.key_uri_format("Provider1:alice@gmail.com", Some("Provider1"));
+        assert_eq!(
+            uri,
+            "otpauth://hotp/Provider1:alice@gmail.com?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&issuer=Provider1&counter=0&algorithm=SHA1&digits=6"
+        );
+    }
+
+    #[test]
+    fn test_key_uri_format_empty_values() {
+        let key_ascii = "12345678901234567890".to_owned();
+        let mut hotp = HOTPBuilder::new()
+            .ascii_key(&key_ascii)
+            .finalize()
+            .unwrap();
+
+        let uri = hotp.key_uri_format("", None);
+        assert_eq!(
+            uri,
+            "otpauth://hotp/?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&counter=0&algorithm=SHA1&digits=6"
+        );
     }
 }

--- a/src/oath/hotp.rs
+++ b/src/oath/hotp.rs
@@ -1,4 +1,4 @@
-use super::{ErrorCode, HashFunction};
+use super::{ErrorCode, HashFunction, KeyUriBuilder, UriType};
 use base32;
 use base64;
 use hex;
@@ -196,15 +196,15 @@ impl HOTP {
         code == ref_code
     }
 
-    /// Returns the Key Uri Format according to the [Google authenticator
+    /// Creates the Key Uri Format according to the [Google authenticator
     /// specification](https://github.com/google/google-authenticator/wiki/Key-Uri-Format).
     /// This value can be used to generete QR codes which allow easy scanning by the end user.
-    /// Passing a issuer value and prefixing the label with that value is highly recommended.
+    /// The returned [`KeyUriBuilder`] allows for additional customizations.
     ///
-    /// **WARNING**: The return value contains the secret key of the authentication process and
-    /// should only be displayed to the corresponding user.
+    /// **WARNING**: The finalized value contains the secret key of the authentication process and
+    /// should only be displayed to the corresponding user!
     ///
-    /// ## Examples
+    /// ## Example
     ///
     /// ```
     /// let key_ascii = "12345678901234567890".to_owned();
@@ -213,55 +213,30 @@ impl HOTP {
     ///     .finalize()
     ///     .unwrap();
     ///
-    /// let uri = hotp.key_uri_format("Provider1:alice@gmail.com", Some("Provider1"));
+    /// let uri = hotp
+    ///     .key_uri_format("Provider1", "alice@gmail.com")
+    ///     .finalize();
+    ///
     /// assert_eq!(
     ///     uri,
-    ///     "otpauth://hotp/Provider1:alice@gmail.com?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&issuer=Provider1&counter=0&algorithm=SHA1&digits=6"
+    ///     "otpauth://hotp/Provider1:alice%40gmail.com?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&issuer=Provider1&algorithm=SHA1&digits=6&counter=0"
     /// );
     /// ```
-    pub fn key_uri_format(&self, label: &str, issuer: Option<&str>) -> String {
-        let secret = base32::encode(
-            base32::Alphabet::RFC4648 { padding: false },
-            self.key.as_slice(),
-        );
-
-        // STRONGLY RECOMMENDED: The issuer parameter is a string value indicating the 
-        // provider or service this account is associated with. If the issuer parameter
-        // is absent, issuer information may be taken from the issuer prefix of the label.
-        // If both issuer parameter and issuer label prefix are present, they should be equal.
-        let mut issuer_param = String::new();
-        if issuer.is_some() {
-            issuer_param = format!("&issuer={}", issuer.unwrap());
+    pub fn key_uri_format<'a>(&'a self, issuer: &'a str, account_name: &'a str) -> KeyUriBuilder<'a> {
+        KeyUriBuilder {
+            uri_type: UriType::HOTP,
+            key: &self.key,
+            issuer: issuer,
+            issuer_param: true, // add issuer to parameters?
+            account_name: account_name,
+            label: None,
+            parameters: None,
+            parameters_encode: false,
+            algo: Some(self.hash_function),
+            digits: Some(self.output_len),
+            counter: Some(self.counter), // Required!
+            period: None,
         }
-
-        // OPTIONAL: The algorithm may have the values: SHA1 (Default), SHA256, SHA512
-        use super::HashFunction::*;
-        let algo = match self.hash_function {
-            Sha1 => "&algorithm=SHA1",
-            Sha256 => "&algorithm=SHA256",
-            Sha512 => "&algorithm=SHA512",
-            _ => "",
-        };
-
-        // OPTIONAL: The digits parameter may have the values 6 or 8, and determines how
-        // long of a one-time passcode to display to the user. The default is 6.
-        let out_len = self.output_len;
-        let mut digits = String::new();
-        if out_len == 6 || out_len == 8 {
-            digits = format!("&digits={}", out_len);
-        }
-
-        // REQUIRED if type is hotp: The counter parameter is required when provisioning 
-        // a key for use with HOTP. It will set the initial counter value.
-        let counter = format!("&counter={}", self.counter);
-
-        format!(
-            "otpauth://{key_type}/{label}?secret={secret}{params}",
-            key_type = "hotp",
-            label = label,
-            secret = secret,
-            params =  issuer_param + &counter + &algo + &digits,
-        )
     }
 }
 
@@ -1411,25 +1386,111 @@ mod tests {
             .finalize()
             .unwrap();
 
-        let uri = hotp.key_uri_format("Provider1:alice@gmail.com", Some("Provider1"));
+        let uri = hotp
+            .key_uri_format("Provider1", "alice@gmail.com")
+            .finalize();
+
         assert_eq!(
             uri,
-            "otpauth://hotp/Provider1:alice@gmail.com?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&issuer=Provider1&counter=0&algorithm=SHA1&digits=6"
+            "otpauth://hotp/Provider1:alice%40gmail.com?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&issuer=Provider1&algorithm=SHA1&digits=6&counter=0"
         );
     }
 
     #[test]
-    fn test_key_uri_format_empty_values() {
+    fn test_key_uri_format_disable_parameters() {
         let key_ascii = "12345678901234567890".to_owned();
         let mut hotp = HOTPBuilder::new()
             .ascii_key(&key_ascii)
             .finalize()
             .unwrap();
 
-        let uri = hotp.key_uri_format("", None);
+        let uri = hotp
+            .key_uri_format("Provider1", "alice@gmail.com")
+            .disable_issuer()
+            .disable_hash_function()
+            .disable_digits()
+            .finalize();
+
         assert_eq!(
             uri,
-            "otpauth://hotp/?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&counter=0&algorithm=SHA1&digits=6"
+            "otpauth://hotp/Provider1:alice%40gmail.com?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&counter=0"
+        );
+    }
+
+    #[test]
+    fn test_key_uri_format_overwrite_label() {
+        let key_ascii = "12345678901234567890".to_owned();
+        let mut hotp = HOTPBuilder::new()
+            .ascii_key(&key_ascii)
+            .finalize()
+            .unwrap();
+
+        let uri = hotp
+            .key_uri_format("Provider1", "alice@gmail.com")
+            .overwrite_label("Provider1Label")
+            .finalize();
+
+        assert_eq!(
+            uri,
+            "otpauth://hotp/Provider1Label?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&issuer=Provider1&algorithm=SHA1&digits=6&counter=0"
+        );
+    }
+
+    #[test]
+    fn test_key_uri_format_overwrite_parameters() {
+        let key_ascii = "12345678901234567890".to_owned();
+        let mut hotp = HOTPBuilder::new()
+            .ascii_key(&key_ascii)
+            .finalize()
+            .unwrap();
+
+        let uri = hotp
+            .key_uri_format("Provider1", "alice@gmail.com")
+            .overwrite_parameters("Provider1Parameters and more", false)
+            .finalize();
+
+        assert_eq!(
+            uri,
+            "otpauth://hotp/Provider1:alice%40gmail.com?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&Provider1Parameters and more"
+        );
+    }
+
+    #[test]
+    fn test_key_uri_format_overwrite_both() {
+        let key_ascii = "12345678901234567890".to_owned();
+        let mut hotp = HOTPBuilder::new()
+            .ascii_key(&key_ascii)
+            .finalize()
+            .unwrap();
+
+        let uri = hotp
+            .key_uri_format("Provider1", "alice@gmail.com")
+            .overwrite_label("Provider1Label")
+            .overwrite_parameters("Provider1Parameters", false)
+            .finalize();
+
+        assert_eq!(
+            uri,
+            "otpauth://hotp/Provider1Label?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&Provider1Parameters"
+        );
+    }
+
+    #[test]
+    fn test_key_uri_format_overwrite_parameters_encoded() {
+        let key_ascii = "12345678901234567890".to_owned();
+        let mut hotp = HOTPBuilder::new()
+            .ascii_key(&key_ascii)
+            .finalize()
+            .unwrap();
+
+        let uri = hotp
+            .key_uri_format("Provider1", "alice@gmail.com")
+            .overwrite_parameters("Provider1Parameters and more", true) // true => URL-encode
+            .finalize();
+
+        assert_eq!(
+            uri,
+            "otpauth://hotp/Provider1:alice%40gmail.com?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&Provider1Parameters%20and%20more"
         );
     }
 }

--- a/src/oath/mod.rs
+++ b/src/oath/mod.rs
@@ -157,6 +157,265 @@ pub enum ErrorCode {
     CodeInvalidUTF8 = 30,
 }
 
+#[derive(Eq, PartialEq)]
+enum UriType {
+    TOTP,
+    HOTP,
+}
+
+/// Creates the Key Uri Format according to the [Google authenticator
+/// specification](https://github.com/google/google-authenticator/wiki/Key-Uri-Format) by calling
+/// `key_uri_format()` on [`HOTP`] or [`TOTP`]. This value can be used to generete QR
+/// codes which allow easy scanning by the end user.
+///
+/// **WARNING**: The finalized value contains the secret key of the authentication process and
+/// should only be displayed to the corresponding user!
+///
+/// ## Example
+///
+/// ```
+/// let key_ascii = "12345678901234567890".to_owned();
+/// let mut totp = libreauth::oath::TOTPBuilder::new()
+///     .ascii_key(&key_ascii)
+///     .finalize()
+///     .unwrap();
+///
+/// let uri = totp
+///     .key_uri_format("Provider1", "alice@gmail.com")
+///     .finalize();
+///
+/// assert_eq!(
+///     uri,
+///     "otpauth://totp/Provider1:alice%40gmail.com?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&issuer=Provider1&algorithm=SHA1&digits=6&period=30"
+/// );
+/// ```
+pub struct KeyUriBuilder<'a> {
+    uri_type: UriType,
+    key: &'a Vec<u8>,
+    issuer: &'a str,
+    issuer_param: bool, // add issuer to parameters?
+    account_name: &'a str,
+    label: Option<&'a str>,
+    parameters: Option<&'a str>,
+    parameters_encode: bool, // URL-encode custom parameter?
+    algo: Option<HashFunction>,
+    digits: Option<usize>,
+    counter: Option<u64>,
+    period: Option<u32>,
+}
+
+impl<'a> KeyUriBuilder<'a> {
+    /// Do not append the issuer to the parameters section.
+    pub fn disable_issuer(mut self) -> Self {
+        self.issuer_param = false;
+        self
+    }
+    /// Do not append the hash function to the parameters section.
+    pub fn disable_hash_function(mut self) -> Self {
+        self.algo = None;
+        self
+    }
+    /// Do not append digits to the parameters section.
+    pub fn disable_digits(mut self) -> Self {
+        self.digits = None;
+        self
+    }
+    /// Do not append the period to the parameters section.
+    pub fn disable_period(mut self) -> Self{
+        self.period = None;
+        self
+    }
+    /// Completely overwrite the default `{issuer}:{account_name}` label with a custom one.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let key_ascii = "12345678901234567890".to_owned();
+    /// let mut totp = libreauth::oath::TOTPBuilder::new()
+    ///     .ascii_key(&key_ascii)
+    ///     .finalize()
+    ///     .unwrap();
+    ///
+    /// let uri = totp
+    ///     .key_uri_format("Provider1", "alice@gmail.com")
+    ///     .overwrite_label("Provider1Label")
+    ///     .finalize();
+    ///
+    /// assert_eq!(
+    ///     uri,
+    ///     "otpauth://totp/Provider1Label?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&issuer=Provider1&algorithm=SHA1&digits=6&period=30"
+    /// );
+    /// ```
+    pub fn overwrite_label(mut self, label: &'a str) -> Self {
+        self.label = Some(label);
+        self
+    }
+    /// Completely overwrite the default parameters section with a custom one.
+    /// Set `url_encode` to `true` to have it URL-encoded.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let key_ascii = "12345678901234567890".to_owned();
+    /// let mut totp = libreauth::oath::TOTPBuilder::new()
+    ///     .ascii_key(&key_ascii)
+    ///     .finalize()
+    ///     .unwrap();
+    ///
+    /// let uri = totp
+    ///     .key_uri_format("Provider1", "alice@gmail.com")
+    ///     .overwrite_parameters("Provider1Parameters", false)
+    ///     .finalize();
+    ///
+    /// assert_eq!(
+    ///     uri,
+    ///     "otpauth://totp/Provider1:alice%40gmail.com?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&Provider1Parameters"
+    /// );
+    /// ```
+    pub fn overwrite_parameters(mut self, parameters: &'a str, url_encode: bool) -> Self {
+        self.parameters = Some(parameters);
+        self.parameters_encode = url_encode;
+        self
+    }
+    /// Generate the final format.
+    pub fn finalize(&self) -> String {
+        let secret_final = base32::encode(
+            base32::Alphabet::RFC4648 { padding: false },
+            self.key.as_slice(),
+        );
+
+        use self::UriType::*;
+        let uri_type_final = match self.uri_type {
+            TOTP => "totp".to_string(),
+            HOTP => "hotp".to_string(),
+        };
+
+        // Create the label according to the recommendations,
+        // unless a custom label was set (overwritten).
+        let label_final = match self.label {
+            Some(label) => label.to_string(), // Custom label
+            None => format!("{}:{}", url_encode(self.issuer), url_encode(self.account_name)),
+        };
+
+        // Create the parameters structure according to the specification,
+        // unless custom parameters were set (overwritten).
+        let parameters_final = match self.parameters {
+            Some(parameters) => { // Custom parameters
+                // Make sure the parameters section starts with `&`
+                let mut prefix = String::new();
+                if !parameters.starts_with('&') {
+                    prefix.push('&');
+                }
+
+                if self.parameters_encode {
+                    prefix.push_str(&url_encode(parameters));
+                } else {
+                    prefix.push_str(parameters);
+                }
+                prefix
+            },
+            None => {
+                // STRONGLY RECOMMENDED: The issuer parameter is a string value indicating the
+                // provider or service this account is associated with. If the issuer parameter
+                // is absent, issuer information may be taken from the issuer prefix of the label.
+                // If both issuer parameter and issuer label prefix are present, they should be equal.
+                let mut issuer_final = String::new();
+                if self.issuer_param {
+                    issuer_final = format!("&issuer={}", url_encode(self.issuer));
+                }
+
+                // OPTIONAL: The algorithm may have the values: SHA1 (Default), SHA256, SHA512.
+                let mut algo_final = String::new();
+                if let Some(algo) = self.algo {
+                    algo_final = match algo {
+                        Sha1 => "&algorithm=SHA1".to_string(),
+                        Sha256 => "&algorithm=SHA256".to_string(),
+                        Sha512 => "&algorithm=SHA512".to_string(),
+                        _ => "".to_string(),
+                    };
+                }
+
+                // OPTIONAL: The digits parameter may have the values 6 or 8, and determines how
+                // long of a one-time passcode to display to the user. The default is 6.
+                let mut digits_final = String::new();
+                if let Some(digits) = self.digits {
+                    digits_final = format!("&digits={}", digits);
+                }
+
+                // REQUIRED if type is hotp: The counter parameter is required when provisioning
+                // a key for use with HOTP. It will set the initial counter value.
+                let mut counter_final = String::new();
+                if self.uri_type == HOTP {
+                    // Unwraping here is safe, since the counter is required for HOTP.
+                    // Panicing would indicate a bug in `HOTP.key_uri_format()`.
+                    counter_final = format!("&counter={}", self.counter.unwrap());
+                }
+
+                // OPTIONAL only if type is totp: The period parameter defines a period that a
+                // TOTP code will be valid for, in seconds. The default value is 30.
+                let mut period_final = String::new();
+                if let Some(period) = self.period {
+                    period_final = format!("&period={}", period);
+                }
+
+                format!(
+                    "{issuer}{algo}{digits}{counter}{period}",
+                    issuer = issuer_final,
+                    algo = algo_final,
+                    digits = digits_final,
+                    counter = counter_final,
+                    period = period_final,
+                )
+            }
+        };
+
+        format!(
+            "otpauth://{uri_type}/{label}?secret={secret}{params}",
+            uri_type = uri_type_final,
+            label = label_final,
+            secret = secret_final,
+            params = parameters_final,
+        )
+    }
+}
+
+/// The source code within this function was taken from the
+/// [rust_urlencoding](https://github.com/bt/rust_urlencoding) library.
+///
+/// Copyright (c) 2016 Bertram Truong
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+///
+/// The above copyright notice and this permission notice shall be included in
+/// all copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+/// THE SOFTWARE.
+fn url_encode(data: &str) -> String {
+    let mut escaped = String::new();
+    for b in data.as_bytes().iter() {
+        match *b as char {
+            // Accepted characters
+            'A'...'Z' | 'a'...'z' | '0'...'9' | '-' | '_' | '.' | '~' => escaped.push(*b as char),
+
+            // Everything else is percent-encoded
+            b => escaped.push_str(format!("%{:02X}", b as u32).as_str()),
+        };
+    }
+    return escaped;
+}
+
+
 macro_rules! builder_common {
     ($t:ty) => {
         /// Sets the shared secret.

--- a/src/oath/totp.rs
+++ b/src/oath/totp.rs
@@ -88,6 +88,74 @@ impl TOTP {
         }
         false
     }
+
+    /// Returns the Key Uri Format according to the [Google authenticator
+    /// specification](https://github.com/google/google-authenticator/wiki/Key-Uri-Format).
+    /// This value can be used to generete QR codes which allow easy scanning by the end user.
+    /// Passing a issuer value and prefixing the label with that value is highly recommended.
+    ///
+    /// **WARNING**: The return value contains the secret key of the authentication process and
+    /// should only be displayed to the corresponding user.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// let key_ascii = "12345678901234567890".to_owned();
+    /// let mut totp = libreauth::oath::TOTPBuilder::new()
+    ///     .ascii_key(&key_ascii)
+    ///     .finalize()
+    ///     .unwrap();
+    ///
+    /// let uri = totp.key_uri_format("Provider1:alice@gmail.com", Some("Provider1"));
+    /// assert_eq!(
+    ///     uri,
+    ///     "otpauth://totp/Provider1:alice@gmail.com?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&issuer=Provider1&algorithm=SHA1&digits=6&period=30"
+    /// );
+    /// ```
+    pub fn key_uri_format(&self, label: &str, issuer: Option<&str>) -> String {
+        let secret = base32::encode(
+            base32::Alphabet::RFC4648 { padding: false },
+            self.key.as_slice(),
+        );
+
+        // STRONGLY RECOMMENDED: The issuer parameter is a string value indicating the 
+        // provider or service this account is associated with. If the issuer parameter
+        // is absent, issuer information may be taken from the issuer prefix of the label.
+        // If both issuer parameter and issuer label prefix are present, they should be equal.
+        let mut issuer_param = String::new();
+        if issuer.is_some() {
+            issuer_param = format!("&issuer={}", issuer.unwrap());
+        }
+
+        // OPTIONAL: The algorithm may have the values: SHA1 (Default), SHA256, SHA512
+        use super::HashFunction::*;
+        let algo = match self.hash_function {
+            Sha1 => "&algorithm=SHA1",
+            Sha256 => "&algorithm=SHA256",
+            Sha512 => "&algorithm=SHA512",
+            _ => "",
+        };
+
+        // OPTIONAL: The digits parameter may have the values 6 or 8, and determines how
+        // long of a one-time passcode to display to the user. The default is 6.
+        let out_len = self.output_len;
+        let mut digits = String::new();
+        if out_len == 6 || out_len == 8 {
+            digits = format!("&digits={}", out_len);
+        }
+
+        // OPTIONAL only if type is totp: The period parameter defines a period that a
+        // TOTP code will be valid for, in seconds. The default value is 30.
+        let period = format!("&period={}", self.period);
+
+        format!(
+            "otpauth://{key_type}/{label}?secret={secret}{params}",
+            key_type = "totp",
+            label = label,
+            secret = secret,
+            params =  issuer_param + algo + &digits + &period,
+        )
+    }
 }
 
 /// Builds a TOTP object.
@@ -986,5 +1054,35 @@ mod tests {
             .unwrap()
             .is_valid(&user_code);
         assert_eq!(valid, false);
+    }
+
+    #[test]
+    fn test_key_uri_format() {
+        let key_ascii = "12345678901234567890".to_owned();
+        let mut hotp = TOTPBuilder::new()
+            .ascii_key(&key_ascii)
+            .finalize()
+            .unwrap();
+
+        let uri = hotp.key_uri_format("Provider1:alice@gmail.com", Some("Provider1"));
+        assert_eq!(
+            uri,
+            "otpauth://totp/Provider1:alice@gmail.com?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&issuer=Provider1&algorithm=SHA1&digits=6&period=30"
+        );
+    }
+
+    #[test]
+    fn test_key_uri_format_empty_values() {
+        let key_ascii = "12345678901234567890".to_owned();
+        let mut hotp = TOTPBuilder::new()
+            .ascii_key(&key_ascii)
+            .finalize()
+            .unwrap();
+
+        let uri = hotp.key_uri_format("", None);
+        assert_eq!(
+            uri,
+            "otpauth://totp/?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&algorithm=SHA1&digits=6&period=30"
+        );
     }
 }


### PR DESCRIPTION
Hello

This pull request contains the `key_uri_format()` method for the HOTP and TOTP types. This implementation was written according to the official [Google specification](https://github.com/google/google-authenticator/wiki/Key-Uri-Format). This format is used to generate QR codes.

Example:
```
let key_ascii = "12345678901234567890".to_owned();
let mut totp = libreauth::oath::TOTPBuilder::new()
    .ascii_key(&key_ascii)
    .finalize()
    .unwrap();

let uri = totp.key_uri_format("Provider1:alice@gmail.com", Some("Provider1"));
assert_eq!(
    uri,
    "otpauth://totp/Provider1:alice@gmail.com?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&issuer=Provider1&algorithm=SHA1&digits=6&period=30"
);
```
I've tested this on Android and it works fine. The tests were compared to the results of the [following generator](https://stefansundin.github.io/2fa-qr/).

Open considerations:
- This feature is not implemented for the C bindings.
- Certain apps such as FreeOTP will crash if the label is empty (""). Should this method return an error if that's the case? In the end, it's up to the developer to choose the label and requirements should not be enforced by this library.