### PR TITLE
Improve Rust error API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - The minimal required Rust version is now Rust 1.60.
+- ⚠️ BREAKING: All Rust functions that previously returned `Result<_, ErrorCode>` now return `Result<_, Error>`
 
 
 ## [0.15.0] - 2022-04-03

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,5 +43,6 @@ rust-argon2 = { version = "^1.0", optional = true }
 sha-1 = { version = "^0.10", optional = true }
 sha2 = { version = "^0.10", optional = true }
 sha3 = { version = "^0.10", optional = true }
+thiserror = { version = "1.0.40", optional = true }
 unicode-normalization = { version = "^0.1", optional = true }
 url = { version = "^2.1", optional = true }

--- a/src/oath/cbindings.rs
+++ b/src/oath/cbindings.rs
@@ -218,7 +218,7 @@ pub extern "C" fn libreauth_hotp_generate(cfg: *const HOTPcfg, code: *mut u8) ->
             write_code(&ref_code, code);
             ErrorCode::Success
         }
-        Err(errno) => errno,
+        Err(err) => err.into(),
     }
 }
 
@@ -332,7 +332,7 @@ pub unsafe extern "C" fn libreauth_hotp_get_uri(
             buff[len] = 0;
             ErrorCode::Success
         }
-        Err(errno) => errno,
+        Err(err) => err.into(),
     }
 }
 
@@ -433,7 +433,7 @@ pub extern "C" fn libreauth_totp_generate(cfg: *const TOTPcfg, code: *mut u8) ->
             write_code(&ref_code, code);
             ErrorCode::Success
         }
-        Err(errno) => errno,
+        Err(err) => err.into(),
     }
 }
 
@@ -545,6 +545,6 @@ pub unsafe extern "C" fn libreauth_totp_get_uri(
             buff[len] = 0;
             ErrorCode::Success
         }
-        Err(errno) => errno,
+        Err(err) => err.into(),
     }
 }

--- a/src/oath/hotp.rs
+++ b/src/oath/hotp.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "oath-uri")]
 use super::DEFAULT_KEY_URI_PARAM_POLICY;
 use super::{
-    ErrorCode, HashFunction, DEFAULT_LOOK_AHEAD, DEFAULT_OTP_HASH, DEFAULT_OTP_OUT_BASE,
+    Error, HashFunction, DEFAULT_LOOK_AHEAD, DEFAULT_OTP_HASH, DEFAULT_OTP_OUT_BASE,
     DEFAULT_OTP_OUT_LEN,
 };
 #[cfg(feature = "oath-uri")]
@@ -377,7 +377,7 @@ pub struct HOTPBuilder {
     output_len: usize,
     output_base: String,
     hash_function: HashFunction,
-    runtime_error: Option<ErrorCode>,
+    runtime_error: Option<Error>,
     look_ahead: u64,
 }
 
@@ -416,13 +416,13 @@ impl HOTPBuilder {
     }
 
     /// Returns the finalized HOTP object.
-    pub fn finalize(&self) -> Result<HOTP, ErrorCode> {
+    pub fn finalize(&self) -> Result<HOTP, Error> {
         if let Some(e) = self.runtime_error {
             return Err(e);
         }
         match self.code_length() {
-            n if n < 1_000_000 => return Err(ErrorCode::CodeTooSmall),
-            n if n > 2_147_483_648 => return Err(ErrorCode::CodeTooBig),
+            n if n < 1_000_000 => return Err(Error::CodeTooSmall),
+            n if n > 2_147_483_648 => return Err(Error::CodeTooBig),
             _ => (),
         }
         match self.key {
@@ -434,7 +434,7 @@ impl HOTPBuilder {
                 hash_function: self.hash_function,
                 look_ahead: self.look_ahead,
             }),
-            None => Err(ErrorCode::InvalidKey),
+            None => Err(Error::InvalidKey),
         }
     }
 }

--- a/src/oath/mod.rs
+++ b/src/oath/mod.rs
@@ -119,11 +119,17 @@ pub enum ErrorCode {
 
 /// Errors used for the Rust interface.
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "thiserror", derive(thiserror::Error))]
 pub enum Error {
+    #[cfg_attr(feature = "thiserror", error("Code too small"))]
     CodeTooSmall,
+    #[cfg_attr(feature = "thiserror", error("Code too big"))]
     CodeTooBig,
 
+    #[cfg_attr(feature = "thiserror", error("Invalid key"))]
     InvalidKey,
+
+    #[cfg_attr(feature = "thiserror", error("Invalid period"))]
     InvalidPeriod,
 }
 

--- a/src/oath/mod.rs
+++ b/src/oath/mod.rs
@@ -43,7 +43,7 @@ const DEFAULT_TOTP_PERIOD: u32 = 30;
 const DEFAULT_TOTP_T0: u64 = 0;
 const DEFAULT_LOOK_AHEAD: u64 = 0;
 
-/// Error codes used both in the rust and C interfaces.
+/// Error codes used in the C interface.
 ///
 /// ## C interface
 /// The C interface uses an enum of type `libreauth_oath_errno` and the
@@ -117,6 +117,27 @@ pub enum ErrorCode {
     InvalidUTF8 = 30,
 }
 
+/// Errors used for the Rust interface.
+#[derive(Clone, Copy, Debug)]
+pub enum Error {
+    CodeTooSmall,
+    CodeTooBig,
+
+    InvalidKey,
+    InvalidPeriod,
+}
+
+impl From<Error> for ErrorCode {
+    fn from(error: Error) -> Self {
+        match error {
+            Error::CodeTooSmall => ErrorCode::CodeTooSmall,
+            Error::CodeTooBig => ErrorCode::CodeTooBig,
+            Error::InvalidKey => ErrorCode::InvalidKey,
+            Error::InvalidPeriod => ErrorCode::InvalidPeriod,
+        }
+    }
+}
+
 macro_rules! builder_common {
     ($t:ty) => {
         /// Sets the shared secret.
@@ -138,7 +159,7 @@ macro_rules! builder_common {
                     self.key = Some(k);
                 }
                 Err(_) => {
-                    self.runtime_error = Some(ErrorCode::InvalidKey);
+                    self.runtime_error = Some(Error::InvalidKey);
                 }
             }
             self
@@ -151,7 +172,7 @@ macro_rules! builder_common {
                     self.key = Some(k);
                 }
                 None => {
-                    self.runtime_error = Some(ErrorCode::InvalidKey);
+                    self.runtime_error = Some(Error::InvalidKey);
                 }
             }
             self
@@ -165,7 +186,7 @@ macro_rules! builder_common {
                     self.key = Some(k);
                 }
                 Err(_) => {
-                    self.runtime_error = Some(ErrorCode::InvalidKey);
+                    self.runtime_error = Some(Error::InvalidKey);
                 }
             }
             self

--- a/src/oath/mod.rs
+++ b/src/oath/mod.rs
@@ -118,6 +118,8 @@ pub enum ErrorCode {
 }
 
 /// Errors used for the Rust interface.
+///
+/// *To implement `std::error::Error`, the `thiserror` feature must be activated*
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "thiserror", derive(thiserror::Error))]
 pub enum Error {

--- a/src/oath/totp.rs
+++ b/src/oath/totp.rs
@@ -1,8 +1,8 @@
 #[cfg(feature = "oath-uri")]
 use super::DEFAULT_KEY_URI_PARAM_POLICY;
 use super::{
-    ErrorCode, HOTPBuilder, HashFunction, DEFAULT_OTP_HASH, DEFAULT_OTP_OUT_BASE,
-    DEFAULT_OTP_OUT_LEN, DEFAULT_TOTP_PERIOD, DEFAULT_TOTP_T0,
+    Error, HOTPBuilder, HashFunction, DEFAULT_OTP_HASH, DEFAULT_OTP_OUT_BASE, DEFAULT_OTP_OUT_LEN,
+    DEFAULT_TOTP_PERIOD, DEFAULT_TOTP_T0,
 };
 #[cfg(feature = "oath-uri")]
 use crate::oath::key_uri::{KeyUriBuilder, UriType};
@@ -206,7 +206,7 @@ pub struct TOTPBuilder {
     output_len: usize,
     output_base: String,
     hash_function: HashFunction,
-    runtime_error: Option<ErrorCode>,
+    runtime_error: Option<Error>,
 }
 
 impl Default for TOTPBuilder {
@@ -269,7 +269,7 @@ impl TOTPBuilder {
     /// Sets the time step in seconds (X). May not be zero. Default is 30.
     pub fn period(&mut self, period: u32) -> &mut TOTPBuilder {
         if period == 0 {
-            self.runtime_error = Some(ErrorCode::InvalidPeriod);
+            self.runtime_error = Some(Error::InvalidPeriod);
         } else {
             self.period = period;
         }
@@ -283,13 +283,13 @@ impl TOTPBuilder {
     }
 
     /// Returns the finalized TOTP object.
-    pub fn finalize(&self) -> Result<TOTP, ErrorCode> {
+    pub fn finalize(&self) -> Result<TOTP, Error> {
         if let Some(e) = self.runtime_error {
             return Err(e);
         }
         match self.code_length() {
-            n if n < 1_000_000 => return Err(ErrorCode::CodeTooSmall),
-            n if n > 2_147_483_648 => return Err(ErrorCode::CodeTooBig),
+            n if n < 1_000_000 => return Err(Error::CodeTooSmall),
+            n if n > 2_147_483_648 => return Err(Error::CodeTooBig),
             _ => (),
         }
         match self.key {
@@ -304,7 +304,7 @@ impl TOTPBuilder {
                 output_base: self.output_base.clone(),
                 hash_function: self.hash_function,
             }),
-            None => Err(ErrorCode::InvalidKey),
+            None => Err(Error::InvalidKey),
         }
     }
 }

--- a/src/pass/argon2.rs
+++ b/src/pass/argon2.rs
@@ -1,4 +1,4 @@
-use super::{std_default, ErrorCode, HashingFunction, Normalization};
+use super::{error::Error, std_default, HashingFunction, Normalization};
 use crate::key::KeyBuilder;
 use std::collections::HashMap;
 
@@ -25,9 +25,9 @@ macro_rules! set_param {
                     $obj.$attr = i;
                     Ok(())
                 }
-                _ => Err(ErrorCode::InvalidPasswordFormat),
+                _ => Err(Error::InvalidPasswordFormat),
             },
-            Err(_) => Err(ErrorCode::InvalidPasswordFormat),
+            Err(_) => Err(Error::InvalidPasswordFormat),
         }
     }};
 }
@@ -71,13 +71,13 @@ impl HashingFunction for Argon2Hash {
         params
     }
 
-    fn set_parameter(&mut self, name: &str, value: &str) -> Result<(), ErrorCode> {
+    fn set_parameter(&mut self, name: &str, value: &str) -> Result<(), Error> {
         match name {
             "passes" => set_param!(self, passes, value, u32, MIN_PASSES, MAX_PASSES),
             "mem" => set_param!(self, mem_cost, value, u32, MIN_MEM_COST, MAX_MEM_COST),
             "lanes" => set_param!(self, lanes, value, u32, MIN_LANES, MAX_LANES),
             "len" => set_param!(self, output_len, value, u32, MIN_OUTPUT_LEN, MAX_OUTPUT_LEN),
-            _ => Err(ErrorCode::InvalidPasswordFormat),
+            _ => Err(Error::InvalidPasswordFormat),
         }
     }
 
@@ -85,22 +85,22 @@ impl HashingFunction for Argon2Hash {
         Some(self.salt.clone())
     }
 
-    fn set_salt(&mut self, salt: Vec<u8>) -> Result<(), ErrorCode> {
+    fn set_salt(&mut self, salt: Vec<u8>) -> Result<(), Error> {
         match salt.len() {
             MIN_SALT_LENGTH..=MAX_SALT_LENGTH => {
                 self.salt = salt;
                 Ok(())
             }
-            _ => Err(ErrorCode::InvalidPasswordFormat),
+            _ => Err(Error::InvalidPasswordFormat),
         }
     }
 
-    fn set_salt_len(&mut self, salt_len: usize) -> Result<(), ErrorCode> {
+    fn set_salt_len(&mut self, salt_len: usize) -> Result<(), Error> {
         let salt = KeyBuilder::new().size(salt_len).as_vec();
         self.set_salt(salt)
     }
 
-    fn set_normalization(&mut self, norm: Normalization) -> Result<(), ErrorCode> {
+    fn set_normalization(&mut self, norm: Normalization) -> Result<(), Error> {
         self.norm = norm;
         Ok(())
     }

--- a/src/pass/cbindings.rs
+++ b/src/pass/cbindings.rs
@@ -156,7 +156,7 @@ pub unsafe extern "C" fn libreauth_pass_init_from_phc(
     let checker = match HashBuilder::from_phc(p.as_str()) {
         Ok(ch) => ch,
         Err(e) => {
-            return e;
+            return e.into();
         }
     };
     c.min_len = checker.min_len;
@@ -249,7 +249,7 @@ pub unsafe extern "C" fn libreauth_pass_hash(
     let hasher = match builder.finalize() {
         Ok(ch) => ch,
         Err(e) => {
-            return e;
+            return e.into();
         }
     };
     match hasher.hash(&password) {
@@ -263,7 +263,7 @@ pub unsafe extern "C" fn libreauth_pass_hash(
             buff[len] = 0;
             ErrorCode::Success
         }
-        Err(e) => e,
+        Err(e) => e.into(),
     }
 }
 

--- a/src/pass/error.rs
+++ b/src/pass/error.rs
@@ -68,9 +68,22 @@ pub enum ErrorCode {
 
 /// Errors for the Rust interface.
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "thiserror", derive(thiserror::Error))]
 pub enum Error {
+    #[cfg_attr(
+        feature = "thiserror",
+        error("Password was shorter than the minimal length (actual {actual}, min {min})")
+    )]
     PasswordTooShort { min: usize, actual: usize },
+    #[cfg_attr(
+        feature = "thiserror",
+        error("Password was longer than the maximal length (actual {actual}, max {max})")
+    )]
     PasswordTooLong { max: usize, actual: usize },
+    #[cfg_attr(
+        feature = "thiserror",
+        error("Input does not respect the storage format")
+    )]
     InvalidPasswordFormat,
 }
 

--- a/src/pass/error.rs
+++ b/src/pass/error.rs
@@ -67,6 +67,8 @@ pub enum ErrorCode {
 }
 
 /// Errors for the Rust interface.
+///
+/// *To implement `std::error::Error`, the `thiserror` feature must be activated*
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "thiserror", derive(thiserror::Error))]
 pub enum Error {

--- a/src/pass/error.rs
+++ b/src/pass/error.rs
@@ -1,4 +1,4 @@
-/// Error codes used both in the rust and C interfaces.
+/// Error codes used in the C interface.
 ///
 /// ## C interface
 /// The C interface uses an enum of type `libreauth_pass_errno` and the members has been renamed
@@ -66,14 +66,32 @@ pub enum ErrorCode {
     InvalidKeyLen = 22,
 }
 
+/// Errors for the Rust interface.
+#[derive(Clone, Copy, Debug)]
+pub enum Error {
+    PasswordTooShort { min: usize, actual: usize },
+    PasswordTooLong { max: usize, actual: usize },
+    InvalidPasswordFormat,
+}
+
+impl From<Error> for ErrorCode {
+    fn from(error: Error) -> Self {
+        match error {
+            Error::PasswordTooShort { min: _, actual: _ } => ErrorCode::PasswordTooShort,
+            Error::PasswordTooLong { max: _, actual: _ } => ErrorCode::PasswordTooLong,
+            Error::InvalidPasswordFormat => ErrorCode::InvalidPasswordFormat,
+        }
+    }
+}
+
 impl From<crypto_mac::InvalidKeyLength> for ErrorCode {
     fn from(_error: crypto_mac::InvalidKeyLength) -> Self {
         ErrorCode::InvalidPasswordFormat
     }
 }
 
-impl From<hmac::digest::InvalidLength> for ErrorCode {
+impl From<hmac::digest::InvalidLength> for Error {
     fn from(_error: hmac::digest::InvalidLength) -> Self {
-        ErrorCode::InvalidPasswordFormat
+        Error::InvalidPasswordFormat
     }
 }

--- a/src/pass/mod.rs
+++ b/src/pass/mod.rs
@@ -183,6 +183,7 @@ pub use self::cbindings::libreauth_pass_is_valid;
 pub use self::cbindings::PassCfg;
 #[cfg(feature = "cbindings")]
 pub use self::cbindings::XHMACType;
+pub use self::error::Error;
 pub use error::ErrorCode;
 pub use hash_builder::HashBuilder;
 pub use hasher::Hasher;
@@ -371,11 +372,11 @@ impl XHMAC {
 trait HashingFunction {
     fn get_id(&self) -> String;
     fn get_parameters(&self) -> HashMap<String, String>;
-    fn set_parameter(&mut self, name: &str, value: &str) -> Result<(), ErrorCode>;
+    fn set_parameter(&mut self, name: &str, value: &str) -> Result<(), Error>;
     fn get_salt(&self) -> Option<Vec<u8>>;
-    fn set_salt(&mut self, salt: Vec<u8>) -> Result<(), ErrorCode>;
-    fn set_salt_len(&mut self, salt_len: usize) -> Result<(), ErrorCode>;
-    fn set_normalization(&mut self, norm: Normalization) -> Result<(), ErrorCode>;
+    fn set_salt(&mut self, salt: Vec<u8>) -> Result<(), Error>;
+    fn set_salt_len(&mut self, salt_len: usize) -> Result<(), Error>;
+    fn set_normalization(&mut self, norm: Normalization) -> Result<(), Error>;
     fn hash(&self, input: &[u8]) -> Vec<u8>;
 }
 

--- a/src/pass/pbkdf2.rs
+++ b/src/pass/pbkdf2.rs
@@ -1,4 +1,5 @@
-use super::{std_default, ErrorCode, HashingFunction, Normalization};
+use super::error::Error;
+use super::{std_default, HashingFunction, Normalization};
 use crate::hash::HashFunction;
 use crate::key::KeyBuilder;
 use hmac::Hmac;
@@ -61,7 +62,7 @@ impl HashingFunction for Pbkdf2Hash {
         params
     }
 
-    fn set_parameter(&mut self, name: &str, value: &str) -> Result<(), ErrorCode> {
+    fn set_parameter(&mut self, name: &str, value: &str) -> Result<(), Error> {
         match name {
             "iter" => match value.parse::<u32>() {
                 Ok(i) => match i {
@@ -69,18 +70,18 @@ impl HashingFunction for Pbkdf2Hash {
                         self.nb_iter = i;
                         Ok(())
                     }
-                    _ => Err(ErrorCode::InvalidPasswordFormat),
+                    _ => Err(Error::InvalidPasswordFormat),
                 },
-                Err(_) => Err(ErrorCode::InvalidPasswordFormat),
+                Err(_) => Err(Error::InvalidPasswordFormat),
             },
             "hash" | "hmac" => match HashFunction::from_str(value) {
                 Ok(h) => {
                     self.hash_function = h;
                     Ok(())
                 }
-                Err(_) => Err(ErrorCode::InvalidPasswordFormat),
+                Err(_) => Err(Error::InvalidPasswordFormat),
             },
-            _ => Err(ErrorCode::InvalidPasswordFormat),
+            _ => Err(Error::InvalidPasswordFormat),
         }
     }
 
@@ -88,22 +89,22 @@ impl HashingFunction for Pbkdf2Hash {
         Some(self.salt.clone())
     }
 
-    fn set_salt(&mut self, salt: Vec<u8>) -> Result<(), ErrorCode> {
+    fn set_salt(&mut self, salt: Vec<u8>) -> Result<(), Error> {
         match salt.len() {
             MIN_SALT_LENGTH..=MAX_SALT_LENGTH => {
                 self.salt = salt;
                 Ok(())
             }
-            _ => Err(ErrorCode::InvalidPasswordFormat),
+            _ => Err(Error::InvalidPasswordFormat),
         }
     }
 
-    fn set_salt_len(&mut self, salt_len: usize) -> Result<(), ErrorCode> {
+    fn set_salt_len(&mut self, salt_len: usize) -> Result<(), Error> {
         let salt = KeyBuilder::new().size(salt_len).as_vec();
         self.set_salt(salt)
     }
 
-    fn set_normalization(&mut self, norm: Normalization) -> Result<(), ErrorCode> {
+    fn set_normalization(&mut self, norm: Normalization) -> Result<(), Error> {
         self.norm = norm;
         Ok(())
     }


### PR DESCRIPTION
Added `Error` type inside the `pass` and `oath` modules. This is now used for the Rust code, and is only converted into an `ErrorCode` for the C bindings.

Closes #51