### PR TITLE
Migrate deprecated dependency `crypto-mac` to `digest`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,14 +27,14 @@ hash = ["hmac", "sha-1", "sha2", "sha3"]
 key = ["base32", "base64", "hex", "getrandom"]
 oath = ["base32", "base64", "hash", "hex"]
 oath-uri = ["oath", "url"]
-pass = ["balloon-hash", "base64", "crypto-mac", "hash", "key", "nom", "pbkdf2", "rust-argon2", "unicode-normalization"]
+pass = ["balloon-hash", "base64", "digest", "hash", "key", "nom", "pbkdf2", "rust-argon2", "unicode-normalization"]
 stderror = ["thiserror"]
 
 [dependencies]
 balloon-hash = { version = "0.4.0", default-features = false, optional = true, features = ["alloc"] }
 base32 = { version = "0.4.0", default-features = false, optional = true }
 base64 = { version = "0.22.0", default-features = false, optional = true, features = ["std"] }
-crypto-mac = { version = "0.11.1", default-features = false, optional = true }
+digest = { version = "0.10.0", default-features = false, optional = true,  features = ["mac"] }
 getrandom = { version = "0.2.9", default-features = false, optional = true }
 hex = { version = "0.4.3", default-features = false, optional = true, features = ["std"] }
 hmac = { version = "0.12.1", default-features = false, optional = true }

--- a/src/pass/error.rs
+++ b/src/pass/error.rs
@@ -99,8 +99,8 @@ impl From<Error> for ErrorCode {
 	}
 }
 
-impl From<crypto_mac::InvalidKeyLength> for ErrorCode {
-	fn from(_error: crypto_mac::InvalidKeyLength) -> Self {
+impl From<digest::InvalidLength> for ErrorCode {
+	fn from(_error: digest::InvalidLength) -> Self {
 		ErrorCode::InvalidPasswordFormat
 	}
 }


### PR DESCRIPTION
This crate was merged into `digest`.

The last published `crypto-mac` dependency on `subtle` [is pinned](https://docs.rs/crate/crypto-mac/latest/source/Cargo.toml.orig) and has started causing issues.

> ```
> subtle = { version = "=2.4", default-features = false }
> ```

Unfortunately, the `impl From<crypto_mac::InvalidKeyLength> for ErrorCode` makes this a breaking change.